### PR TITLE
Default to bracket view when tournament starts

### DIFF
--- a/tournament-app/src/app/page.tsx
+++ b/tournament-app/src/app/page.tsx
@@ -69,6 +69,7 @@ export default function Home() {
       isComplete: false,
     });
     setError(null);
+    setActiveTab('bracket');
   };
 
   const runNextRound = async () => {
@@ -134,6 +135,7 @@ export default function Home() {
     setEditedCandidates(new Set());
     setError(null);
     setIsPaused(false);
+    setActiveTab('candidates');
   };
 
   return (


### PR DESCRIPTION
## Summary
- switch to Binary Reduction Tree tab when a tournament begins
- return to Candidates tab when the tournament is reset

## Testing
- `npm test` (fails: Missing script: "test")
- `NEXT_TELEMETRY_DISABLED=1 npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba9598ad0083219de051ad929f262e