### PR TITLE
Default to bracket view when tournament starts

### DIFF
--- a/tournament-app/src/app/page.tsx
+++ b/tournament-app/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { tournamentAPI } from '@/lib/tournament-api';
 import { Candidate, TournamentState, RoundData } from '@/types/tournament';
 import { TournamentSettings } from '@/components/TournamentSettings';
@@ -135,6 +135,11 @@ export default function Home() {
     setError(null);
     setIsPaused(false);
   };
+
+  // Ensure the Binary Reduction Tree is shown while the tournament runs
+  useEffect(() => {
+    setActiveTab(tournamentState.currentRound > 0 ? 'bracket' : 'candidates');
+  }, [tournamentState.currentRound]);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 p-1">


### PR DESCRIPTION
## Summary
- switch to Binary Reduction Tree tab automatically whenever a tournament is active
- fall back to Candidates tab when the tournament is reset

## Testing
- `npm test` (fails: Missing script: "test")
- `NEXT_TELEMETRY_DISABLED=1 npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba9598ad0083219de051ad929f262e